### PR TITLE
k8s  - testing readiness probe

### DIFF
--- a/k8s-azure-flask-app.yaml
+++ b/k8s-azure-flask-app.yaml
@@ -31,6 +31,12 @@ spec:
         image: rsepamacr.azurecr.io/flaskapp-dev:__Build.BuildId__
         ports:
         - containerPort: 80
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          periodSeconds: 3
+          timeoutSeconds: 1
         resources:
             requests:
               memory: "64Mi"


### PR DESCRIPTION
tried to add k8s readiness probe to deployment
readinessProbe:
          httpGet:
            path: /
            port: 80
          periodSeconds: 3
          timeoutSeconds: 1